### PR TITLE
refactor class names used for jQuery selectors

### DIFF
--- a/index.html
+++ b/index.html
@@ -29,11 +29,13 @@
       <article class="article">
         <h2 class="pri-clr">&lt;h2&gt;Article</h2>
         <p class="pri-clr">&lt;p&gt;Lorem ipsum</p>
-        <a id="rush-open" class="a-btn rush" href="#">Rush</a>
-        <a id="football-open" class="a-btn football" href="#">Football</a>
-        <a id="silly-open" class="a-btn silly" href="#">Silly</a>
-        <a id="sums-open" class="a-btn sums" href="#">Sums</a>
-        <a id="color-open" class="a-btn color" href="#">Color</a>
+        <a id="rush-open" class="a-btn rush-open-js" href="#">Rush</a>
+        <a id="football-open" class="a-btn football-open-js" href="#"
+          >Football</a
+        >
+        <a id="silly-open" class="a-btn silly-open-js" href="#">Silly</a>
+        <a id="sums-open" class="a-btn sums-open-js" href="#">Sums</a>
+        <a id="color-open" class="a-btn color-open-js" href="#">Color</a>
       </article>
     </main>
 
@@ -102,19 +104,19 @@
             <div class="col">
               <article class="sidebar">
                 <div class="rush-bg">
-                  <a href="#" class="rush">Rush Fan Site Refactor</a>
+                  <a href="#" class="rush-open-js">Rush Fan Site Refactor</a>
                 </div>
                 <div class="football-bg">
-                  <a href="#" class="football">Football Season Sim</a>
+                  <a href="#" class="football-open-js">Football Season Sim</a>
                 </div>
                 <div class="silly-bg">
-                  <a href="#" class="silly">Silly Personal Page</a>
+                  <a href="#" class="silly-open-js">Silly Personal Page</a>
                 </div>
                 <div class="sums-bg">
-                  <a href="#" class="sums">Sums and Nums</a>
+                  <a href="#" class="sums-open-js">Sums and Nums</a>
                 </div>
                 <div class="color-bg">
-                  <a href="#" class="color">Frankenstein Color Mixer</a>
+                  <a href="#" class="color-open-js">Frankenstein Color Mixer</a>
                 </div>
               </article>
             </div>

--- a/scripts/index.js
+++ b/scripts/index.js
@@ -2,31 +2,31 @@ console.log('//External script file being read from scripts/script.js');
 
 let cont = {};
 
-$('.rush').click(function () {
+$('.rush-open-js').click(function () {
   modal();
   rushPop();
   modalContent();
 });
 
-$('.football').click(function () {
+$('.football-open-js').click(function () {
   modal();
   footballPop();
   modalContent();
 });
 
-$('.silly').click(function () {
+$('.silly-open-js').click(function () {
   modal();
   sillyPop();
   modalContent();
 });
 
-$('.sums').click(function () {
+$('.sums-open-js').click(function () {
   modal();
   sumsPop();
   modalContent();
 });
 
-$('.color').click(function () {
+$('.color-open-js').click(function () {
   modal();
   colorPop();
   modalContent();


### PR DESCRIPTION
Rather than change the classes to id's as originally planned, the names of the classes used for jQuery selectors were changed to incorporate the suffex "...-open-js" to more clearly indicate that the class is being used for opening the given element using javascript.

Example: the class formally named ".rush" was renamed to ".rush-open-js"

This was done to each of the five class names involved: ".rush", ".football", ".silly", ".sums" and ".color"